### PR TITLE
Set the Ring of Power's whisperings to nonblocking

### DIFF
--- a/libnethack/src/do.c
+++ b/libnethack/src/do.c
@@ -283,6 +283,7 @@ dosinkring(struct obj *obj)
         goto giveback;
     case RIN_SLOW_DIGESTION:
         if (obj->oartifact == ART_RING_OF_POWER){
+            suppress_more();
             You_hear("unintelligible whispers");
             break;
         } else {


### PR DESCRIPTION
This will prevent e.x. autoexplore from being interrupted by the ring's
unintelligible whisperings.
