### PR TITLE
Increase MAX_DLB_FILES to 1000

### DIFF
--- a/libnethack/util/dlb_main.c
+++ b/libnethack/util/dlb_main.c
@@ -38,7 +38,7 @@ static const char *list_file = LIBLISTFILE;
 # define O_BINARY 0
 #endif
 
-#define MAX_DLB_FILES 200       /* max # of files we'll handle */
+#define MAX_DLB_FILES 1000       /* max # of files we'll handle */
 #define DLB_VERS 1      /* version of dlb file we will write */
 
 /*


### PR DESCRIPTION
We have more than 200 dlb files, which means that some dungeon / level
files simply weren't being included in a bingehack install.
