### PR TITLE
Drunken Boxing

### DIFF
--- a/libnethack/include/extern.h
+++ b/libnethack/include/extern.h
@@ -630,6 +630,7 @@ extern const char *hist_lev_name(const d_level * l, boolean in_or_on);
 
 /* ### invent.c ### */
 
+extern struct obj *random_type(int, struct monst *);
 extern void assigninvlet(struct obj *);
 extern struct obj *merge_choice(struct obj *, struct obj *);
 extern int merged(struct obj **, struct obj **);
@@ -1690,6 +1691,7 @@ extern void save_you(struct memfile *mf, struct you *y);
 
 /* ### uhitm.c ### */
 
+extern boolean drunkenboxing();
 extern void hurtmarmor(struct monst *, int);
 extern boolean attack_checks(struct monst *, struct obj *, schar, schar);
 extern void check_caitiff(struct monst *);

--- a/libnethack/include/flag.h
+++ b/libnethack/include/flag.h
@@ -106,6 +106,7 @@ struct flag {
     boolean bones_enabled;      /* allow loading bones levels */
     boolean permablind; /* stay permanently blind */
     boolean permahallu; /* stay permanently hallucinating */
+    boolean drunken_boxing;     /* allow drunken boxing */
 };
 
 

--- a/libnethack/src/dokick.c
+++ b/libnethack/src/dokick.c
@@ -138,6 +138,7 @@ kick_monster(xchar x, xchar y, schar dx, schar dy)
     int i, j;
     coord bypos;
     boolean canmove = TRUE;
+    int kc = 1;
 
     bhitpos.x = x;
     bhitpos.y = y;
@@ -215,38 +216,45 @@ kick_monster(xchar x, xchar y, schar dx, schar dy)
     else if (uarm && objects[uarm->otyp].oc_bulky && ACURR(A_DEX) < rnd(25))
         clumsy = TRUE;
 doit:
-    pline("You kick %s.", mon_nam(mon));
-    if (!enexto(&bypos, level, u.ux, u.uy, mon->data) ||
-        !((can_teleport(mon->data) && !level->flags.noteleport) ||
-          ((abs(bypos.x - u.ux) <= 1) && (abs(bypos.y - u.uy) <= 1))))
-        canmove = FALSE;
-    if (!rn2(clumsy ? 3 : 4) && (clumsy || !bigmonst(mon->data)) && mon->mcansee
-        && !mon->mtrapped && !thick_skinned(mon->data) &&
-        mon->data->mlet != S_EEL && haseyes(mon->data) && mon->mcanmove &&
-        !mon->mstun && !mon->mconf && !mon->msleeping &&
-        mon->data->mmove >= 12) {
-        if (!canmove || (!nohands(mon->data) && !rn2(martial()? 5 : 3))) {
-            pline("%s blocks your %skick.", Monnam(mon),
-                  clumsy ? "clumsy " : "");
-            passive(mon, FALSE, 1, AT_KICK);
-            return TRUE;
-        } else {
-            rloc_to(mon, bypos.x, bypos.y);
-            if (mon->mx != x || mon->my != y) {
-                if (level->locations[x][y].mem_invis) {
-                    unmap_object(x, y);
-                    newsym(x, y);
-                }
-                pline("%s %s, %s evading your %skick.", Monnam(mon),
-                      (can_teleport(mon->data) &&
-                       !level->flags.noteleport ? "teleports" :
-                       is_floater(mon->data) ? "floats" :
-                       is_flyer(mon->data) ? "swoops" :
-                       (nolimbs(mon->data) || slithy(mon->data)) ? "slides" :
-                       "jumps"), clumsy ? "easily" : "nimbly",
+    if (drunkenboxing()) {
+        pline("You deliver a flurry of sharp kicks!");
+        kc = (rn2(2) + 2); /* 2 to 4 kicks */
+    } else {
+        pline("You kick %s.", mon_nam(mon));
+    }
+    for (; kc >= 1; kc--) {
+        if (!enexto(&bypos, level, u.ux, u.uy, mon->data) ||
+            !((can_teleport(mon->data) && !level->flags.noteleport) ||
+              ((abs(bypos.x - u.ux) <= 1) && (abs(bypos.y - u.uy) <= 1))))
+            canmove = FALSE;
+        if (!rn2(clumsy ? 3 : 4) && (clumsy || !bigmonst(mon->data)) && mon->mcansee
+            && !mon->mtrapped && !thick_skinned(mon->data) &&
+            mon->data->mlet != S_EEL && haseyes(mon->data) && mon->mcanmove &&
+            !mon->mstun && !mon->mconf && !mon->msleeping &&
+            mon->data->mmove >= 12) {
+            if (!canmove || (!nohands(mon->data) && !rn2(martial()? 5 : 3))) {
+                pline("%s blocks your %skick.", Monnam(mon),
                       clumsy ? "clumsy " : "");
                 passive(mon, FALSE, 1, AT_KICK);
                 return TRUE;
+            } else {
+                rloc_to(mon, bypos.x, bypos.y);
+                if (mon->mx != x || mon->my != y) {
+                    if (level->locations[x][y].mem_invis) {
+                        unmap_object(x, y);
+                        newsym(x, y);
+                    }
+                    pline("%s %s, %s evading your %skick.", Monnam(mon),
+                          (can_teleport(mon->data) &&
+                           !level->flags.noteleport ? "teleports" :
+                           is_floater(mon->data) ? "floats" :
+                           is_flyer(mon->data) ? "swoops" :
+                           (nolimbs(mon->data) || slithy(mon->data)) ? "slides" :
+                           "jumps"), clumsy ? "easily" : "nimbly",
+                          clumsy ? "clumsy " : "");
+                    passive(mon, FALSE, 1, AT_KICK);
+                    return TRUE;
+                }
             }
         }
     }

--- a/libnethack/src/invent.c
+++ b/libnethack/src/invent.c
@@ -87,6 +87,42 @@ assigninvlet(struct obj *otmp)
 /* note: assumes ASCII; toggling a bit puts lowercase in front of uppercase */
 #define inv_rank(o) ((o)->invlet ^ 040)
 
+/* Return a random item from the specified monster's inventory. */
+/* NOTE: This can be you or a monster. */
+/* Types are defined in include/objclass.h. */
+struct obj *
+random_type(type, monster)
+int type;
+struct monst *monster;
+{
+	struct obj *otmp;
+	int count = 0, matches = 0;
+	int sel;
+
+	if (!monster->minvent || type > MAXOCLASSES)
+		return(NULL);
+
+	for (otmp = monster->minvent; otmp; otmp = otmp->nobj) {
+		count++;
+		if (otmp->oclass == type)
+			matches++;
+	}
+
+	if (matches == 0)
+		return(NULL);
+
+	sel = rnd(matches);
+	for (otmp = monster->minvent; otmp; otmp = otmp->nobj) {
+		if (otmp->oclass == type) {
+			sel--;
+			if (sel == 0)
+				break;
+		}
+	}
+
+	return(otmp);
+}
+
 /* sort the inventory; used by addinv() and doorganize() */
 extern void
 reorder_invent(void)

--- a/libnethack/src/mon.c
+++ b/libnethack/src/mon.c
@@ -331,6 +331,16 @@ make_corpse(struct monst *mtmp)
     obj->oinvis = mtmp->minvis;
 #endif
 
+    if (flags.drunken_boxing) {
+        /* 1/20 chance to grab the corpse as it's falling. */
+        int chance = rnd(20);
+        if (chance == 1) {
+                obj_extract_self(obj);
+                hold_another_object(obj, "You try to catch %s but drop it.", doname(obj), "You catch and wield a ");
+                setuwep(obj);
+        }
+    }
+
     stackobj(obj);
     newsym(x, y);
     return obj;

--- a/libnethack/src/options.c
+++ b/libnethack/src/options.c
@@ -185,6 +185,7 @@ static const struct nh_option_desc const_birth_options[] = {
     {"bones", "allow bones levels", OPTTYPE_BOOL, {VTRUE}},
     {"permablind", "spend the whole game blind", OPTTYPE_BOOL, {FALSE}},
     {"permahallu", "spend the whole game hallucinating", OPTTYPE_BOOL, {FALSE}},
+    {"drunkbox", "grand master martial artists can drunken box", OPTTYPE_BOOL, { .b = TRUE}},
     {"legacy", "print introductory message", OPTTYPE_BOOL, {VTRUE}},
     {"align", "your starting alignment", OPTTYPE_ENUM, {(void *)ROLE_NONE}},
     {"gender", "your starting gender", OPTTYPE_ENUM, {(void *)ROLE_NONE}},
@@ -221,6 +222,7 @@ static const struct nh_boolopt_map boolopt_map[] = {
     {"verbose", &flags.verbose},
 
     /* birth options */
+    {"drunkbox", &flags.drunken_boxing},
     {"elbereth", &flags.elbereth_enabled},
     {"reincarnation", &flags.rogue_enabled},
     {"seduction", &flags.seduce_enabled},

--- a/libnethack/src/restore.c
+++ b/libnethack/src/restore.c
@@ -537,6 +537,7 @@ restore_flags(struct memfile *mf, struct flag *f)
     f->bones_enabled = mread8(mf);
     f->permablind = mread8(mf);
     f->permahallu = mread8(mf);
+    f->drunken_boxing = mread8(mf);
 
     mread(mf, f->inv_order, sizeof (f->inv_order));
 }

--- a/libnethack/src/save.c
+++ b/libnethack/src/save.c
@@ -182,6 +182,7 @@ save_flags(struct memfile *mf)
     mwrite8(mf, flags.bones_enabled);
     mwrite8(mf, flags.permablind);
     mwrite8(mf, flags.permahallu);
+    mwrite8(mf, flags.drunken_boxing);
 
     mwrite(mf, flags.inv_order, sizeof (flags.inv_order));
 }


### PR DESCRIPTION
This patch introduces drunken boxing. The drunken throw effect is broken
and had to be removed. Also, drunken boxing is now enabled via a birth
option rather than at compile time.

What follows is the original drunken boxing description taken from it's
authors website: http://nethack.atarininja.org/~wxs/patches/nethack/nethack-343-drunkenboxing.txt

Drunken Boxing spec

Purpose
    Make the weaponless Monk a more interesting and capable endgame
    character without upsetting game balance. This is accomplished
    by introducing a new ability at a certain level similar to the
    Drunken Boxing style of fighting depicted in numerous places
    (to spectacular effect in the Jackie Chan film Drunken Master).

Requirements
    - the player must be a Monk - the player must have attained the
    Grand Master skill level in martial arts - the player must be
    non-polymorphed - the player must have no wielded weapon - the
    player must be confused or stunned

Behavior
    The general idea is to introduce special effect attacks that
    occur during motion in an unintended direction (as when confused
    or stunned). Attacks that occur during this time will have a
    relatively high chance of producing a 'special effect' attack
    with resulting bonus damage. Additional effects would be  a
    bonus to dodge / dodging related stats during unintended motion,
    as well as a slightly higher chance of moving in the intended
    direction when confused/stunned. Each effect should be preceded
    by a regular attack, with damage applied prior to the effect
    taking place.

Effects
    - kicks - 2-4 'kicks' in a single turn
      "You deliver a flurry of sharp kicks!"

```
- throw - knockback effect and falling damage
  the user displaces the monster, only works if free space
  opposite player to displace monster into "You stumble, grappling
  with %m and throwing it to the ground!"

- theft - an attempt at stealing an item
  "Siezing an opportunity, you rifle through %m's pack!"

- blinding - uhh, blinding effect
  "You poke %m in the eye for good measure."

- entanglement - disrobe monster and paralyze it for 2-5 turns
while it disentangles itself
  monster must be wearing armor, armor is removed immediately
  "You pull %m's (armor) (up/down) around its (body part)!"

- roll - skirt past the monster to its opposite side inflicting
some damage as you pass
  space opposite player-monster should be free for player to
  move into "You tumble past %m!"

- corpse as weapon - if the monster is killed, you automatically
wield its body as a weapon
  only works if you are unencumbered and the added weight would
  not encumber you small (very small) bonus chance for this to
  work against 'trices, because that would be bad ass user moves
  into space monster occupied "You catch and wield %m as it
  falls!"
```

STATUS:
The following effects have been implemented in a patch available at
http://www.nethacks.org...
- Kicks
- Theft
- Blinding
- Entanglement
- Corpse As Weapon (needs more testing, not sure what happens when you
  catch a cockatrice)
