### PR TITLE
Make the output files of makedefs depend on makedefs.

### DIFF
--- a/libnethack/dat/CMakeLists.txt
+++ b/libnethack/dat/CMakeLists.txt
@@ -7,28 +7,33 @@ configure_file(history history COPYONLY)
 add_custom_command (OUTPUT data
                     COMMAND makedefs
                     ARGS -d ${LNH_DAT}/data.base data
-                    MAIN_DEPENDENCY data.base)
+                    MAIN_DEPENDENCY data.base
+                    DEPENDS makedefs)
 # makedefs -e
 add_custom_command (OUTPUT dungeon.pdf
                     COMMAND makedefs
                     ARGS -e ${LNH_DAT}/dungeon.def dungeon.pdf
-                    MAIN_DEPENDENCY dungeon.def)
+                    MAIN_DEPENDENCY dungeon.def
+                    DEPENDS makedefs)
 # makedefs -q
 add_custom_command (OUTPUT quest.dat
                     COMMAND makedefs
                     ARGS -q ${LNH_DAT}/quest.txt quest.dat
-                    MAIN_DEPENDENCY quest.txt)
+                    MAIN_DEPENDENCY quest.txt
+                    DEPENDS makedefs)
 # makedefs -r
 add_custom_command (OUTPUT rumors
                     COMMAND makedefs
                     ARGS -r ${LNH_DAT}/rumors.tru
                             ${LNH_DAT}/rumors.fal rumors
-                    DEPENDS rumors.tru rumors.fal)
+                    DEPENDS rumors.tru rumors.fal
+                    DEPENDS makedefs)
 # makedefs -h
 add_custom_command (OUTPUT oracles
                     COMMAND makedefs
                     ARGS -h ${LNH_DAT}/oracles.txt oracles
-                    MAIN_DEPENDENCY oracles.txt)
+                    MAIN_DEPENDENCY oracles.txt
+                    DEPENDS makedefs)
 
 add_custom_command (OUTPUT dungeon
                     COMMAND dgn_comp


### PR DESCRIPTION
Previously, there was an implicit dependency on the _presence_ of
makedefs, but not a hard dependency on it. Since game information which
is written out by makedefs (e.x. artifacts) is compiled directly into
the binary, a weak dependency simply on the presence of makedefs is
insufficient. A strong dependency is needed to make the files generated
by makedefs be rebuilt when e.x. artifacts are added to the game.
