### PR TITLE
implements "The Trident of Fish Command"

### DIFF
--- a/libnethack/include/artifact.h
+++ b/libnethack/include/artifact.h
@@ -35,6 +35,7 @@
 # define SPFX_XRAY   0x2000000L /* gives X-RAY vision to player */
 # define SPFX_REFLECT 0x4000000L/* Reflection */
 # define SPFX_INVIS  0x8000000L /* Invisibility */
+# define SPFX_FISH   0x10000000UL
 
 struct artifact {
     const char *name;

--- a/libnethack/include/artilist.h
+++ b/libnethack/include/artilist.h
@@ -228,6 +228,11 @@ static const struct artifact const_artilist[] = {
       (SPFX_RESTR | SPFX_INTEL | SPFX_INVIS), 0, 0, //It speaks, it is just handled elsewhere (allmain)
       NO_ATTK, NO_DFNS, NO_CARY,
       0, A_NONE, NON_PM, NON_PM, 5000L),
+
+    A("The Trident of Fish Command", TRIDENT,
+      (SPFX_DFLAG1 | SPFX_FISH | SPFX_RESTR), 0, M1_SWIM,
+      PHYS(5, 0), NO_DFNS, NO_CARY,
+      0, A_NONE, NON_PM, NON_PM, 200l),
 /*
  *  terminator; otyp must be zero
  */

--- a/libnethack/include/display.h
+++ b/libnethack/include/display.h
@@ -38,7 +38,7 @@
 
 # define sensemon(mon) (mon->dlevel == level && \
                        (tp_sensemon(mon) || Detect_monsters || \
-                        MATCH_WARN_OF_MON(mon)))
+                        (Detect_fish && is_swimmer(mon->data)) ||MATCH_WARN_OF_MON(mon)))
 
 /*
  * mon_warning() is used to warn of any dangerous monsters in your

--- a/libnethack/include/prop.h
+++ b/libnethack/include/prop.h
@@ -73,7 +73,8 @@
 # define INFRAVISION              64
 # define WARN_OF_MON              65
 # define DETECT_MONSTERS          66
-# define LAST_PROP                (DETECT_MONSTERS)
+# define DETECT_FISH              67
+# define LAST_PROP                (DETECT_FISH)
 
 /*** Where the properties come from ***/
 /* Definitions were moved here from obj.h and you.h */

--- a/libnethack/include/youprop.h
+++ b/libnethack/include/youprop.h
@@ -179,6 +179,9 @@
 # define EDetect_monsters       u.uprops[DETECT_MONSTERS].extrinsic
 # define Detect_monsters        (HDetect_monsters || EDetect_monsters)
 
+# define HDetect_fish           u.uprops[DETECT_FISH].intrinsic
+# define EDetect_fish           u.uprops[DETECT_FISH].extrinsic
+# define Detect_fish            (HDetect_fish || EDetect_fish)
 
 /*** Appearance and behavior ***/
 # define Adornment              u.uprops[ADORNED].extrinsic


### PR DESCRIPTION
![screenshot](http://i.imgur.com/f3DrBqF.png)
- The trident of fish command is a terrible artifact.
- The trident is fishbane, and grants you fish-specific
  detection while you wield it.
  (fishiness is determined by the M1_SWIM flag)
- Technically, it grants the extrinsic effect Detect_fish via
  a new artifact intrinsic called SPFX_FISH
- The trident mostly sucks and just increments the artifact
  counter as a subtle screw you to the player, though
  it might be handy on one particular dungeon level.
