### PR TITLE
Changed how the connection string is formated

### DIFF
--- a/nethack_server/src/db_pgsql.c
+++ b/nethack_server/src/db_pgsql.c
@@ -135,13 +135,13 @@ init_database(void)
 {
     if (conn)
         close_database();
-    int uri_len = asprintf(&uri, "postgresql://%s:%s@%s:%s/%s?%s",
-                           settings.dbuser ? settings.dbuser : "",
-                           settings.dbpass ? settings.dbpass : "",
-                           settings.dbhost ? settings.dbhost : "",
-                           settings.dbport ? settings.dbport : "",
-                           settings.dbname ? settings.dbname : "",
-                           settings.dboptions ? settings.dboptions : "");
+    int uri_len = asprintf(&uri, "user=%s password=%s host=%s port=%s dbname=%s %s",
+                           settings.dbuser ? settings.dbuser : "''",
+                           settings.dbpass ? settings.dbpass : "''",
+                           settings.dbhost ? settings.dbhost : "''",
+                           settings.dbport ? settings.dbport : "''",
+                           settings.dbname ? settings.dbname : "''",
+                           settings.dboptions ? settings.dboptions : "''");
     if (uri_len == -1) {
         fprintf(stderr, "Failed to calloc database URI. %s\n", strerror(errno));
         goto err;


### PR DESCRIPTION
libpq only added the ability to parse postgresql:// URIs in version 9.2. However the CSH server only has libpq 9.1 so I've switched it to use a format that works with 9.1 and 9.2.
