### PR TITLE
Changes to get bingehack running on new gameserver

### DIFF
--- a/libnethack_client/include/nhclient.h
+++ b/libnethack_client/include/nhclient.h
@@ -17,8 +17,6 @@
 
 # include <jansson.h>
 
-# define DEFAULT_PORT 53430
-
 extern struct nh_window_procs client_windowprocs;
 extern int current_game;
 extern jmp_buf ex_jmp_buf;

--- a/libnethack_common/include/nethack_client.h
+++ b/libnethack_common/include/nethack_client.h
@@ -7,6 +7,8 @@
 
 # include "nethack_types.h"
 
+# define DEFAULT_PORT 53430
+
 # ifdef NETHACK_CLIENT_H_IN_LIBNETHACK_CLIENT
 #  define EXPORT(x) AIMAKE_EXPORT(x)
 # else

--- a/nethack/src/netgame.c
+++ b/nethack/src/netgame.c
@@ -713,7 +713,8 @@ netgame(void)
     if (ui_flags.connection_only) {
         servlist = NULL;
         server = &localserver;
-        localserver.hostname = strdup("::1");
+        localserver.hostname = strdup("localhost");
+        localserver.port = 63463;
         if (!get_username_password(&localserver))
             goto finally;
     } else {

--- a/nethack/src/netgame.c
+++ b/nethack/src/netgame.c
@@ -714,7 +714,7 @@ netgame(void)
         servlist = NULL;
         server = &localserver;
         localserver.hostname = strdup("localhost");
-        localserver.port = 63463;
+        localserver.port = DEFAULT_PORT;
         if (!get_username_password(&localserver))
             goto finally;
     } else {

--- a/nethack_server/src/config.c
+++ b/nethack_server/src/config.c
@@ -39,7 +39,8 @@ struct { const char *const name; size_t offset; } settings_map[] = {
     SETTINGS_MAP_ENTRY(dbport),
     SETTINGS_MAP_ENTRY(dbuser),
     SETTINGS_MAP_ENTRY(dbpass),
-    SETTINGS_MAP_ENTRY(dbname)
+    SETTINGS_MAP_ENTRY(dbname),
+    SETTINGS_MAP_ENTRY(dboptions)
 };
 
 static int

--- a/travis-build
+++ b/travis-build
@@ -2,7 +2,7 @@
 set -e
 #set -x
 
-mkdir build
+mkdir -p build
 cd build
 
 if [[ -z "$BUILD_SYSTEM" ]]; then
@@ -16,7 +16,7 @@ elif [[ "$BUILD_SYSTEM" == aimake ]]; then
 	tempfile="$(mktemp)"
 	trap "rm -f \"$tempfile\"" EXIT ERR
 
-	../aimake -i /tmp/bingehack4 2>&1 | tee "$tempfile"
+	../aimake --with=server -i /tmp/bingehack4 2>&1 | tee "$tempfile"
 	grep -qi "fail" "$tempfile" && exit 1
 else
 	echo "Unsupported build system $BUILD_SYSTEM" >&2


### PR DESCRIPTION
The following changes were made to the instance of bingehack4 running currently on neogames-reloaded.

* Add server options for dboptions. This allows us to set `sslmode=required` in order to connect PGSQL to our db server.

* Actually compile the server code, in order to stay more true to the spirit of travis-ci checking for build errors.