### PR TITLE
Fix BingeHack Twitter LDAP Search

### DIFF
--- a/scripts/nethack_events/bingehack-tweeter/bingehack-twitter.rb
+++ b/scripts/nethack_events/bingehack-tweeter/bingehack-twitter.rb
@@ -37,9 +37,7 @@ def get_twitter_username(name)
     scope: LDAP::SearchScope_SingleLevel,
     attributes: ['twitterName']
   ) do |entry|
-    entry.each do |attribute, value|
-      twitterName = value.first
-    end
+         twitterName = entry.twitterName.first
   end
   twitterName
 rescue


### PR DESCRIPTION
The ldap search would previously return the full DN of a user if they did not
have a twitterName entry in their object. This changes the behavior to return
the name that was originally entered if no twitterName exists.