### PR TITLE
Add bingeboard

### DIFF
--- a/nethack_server/include/nhserver.h
+++ b/nethack_server/include/nhserver.h
@@ -126,11 +126,20 @@ extern long db_add_new_game(int uid, const char *filename, const char *role,
                             const char *race, const char *gend,
                             const char *align, int mode, const char *plname,
                             const char *levdesc);
+extern void db_add_binge_entry(int gid, int level, int hp, int max_hp, int gold, int moves,
+                               int energy, int max_energy, int attrib_str, int attrib_int,
+                               int attrib_wis, int attrib_dex, int attrib_con, int attrib_cha,
+                               int score);
 extern void db_update_game(int gameid, int moves, int depth,
                            const char *levdesc);
+extern void db_update_binge_entry(int gid, int level, int hp, int max_hp, int gold, int moves,
+                                  int energy, int max_energy, int attrib_str, int attrib_int,
+                                  int attrib_wis, int attrib_dex, int attrib_con, int attrib_cha,
+                                  int score);
 extern enum getgame_result db_get_game_filename(
     int gid, char *filenamebuf, int buflen);
 extern void db_delete_game(int uid, int gid);
+extern void db_delete_binge_entry(int gid);
 extern struct gamefile_info *db_list_games(int completed, int uid, int limit,
                                            int *count);
 extern void db_add_topten_entry(int gid, int points, int hp, int maxhp,

--- a/nethack_server/src/clientcmd.c
+++ b/nethack_server/src/clientcmd.c
@@ -254,6 +254,12 @@ ccmd_create_game(json_t * params)
                             ri->racenames[race], ri->gendnames[gend],
                             ri->alignnames[align], mode, name,
                             player_info.level_desc);
+        db_add_binge_entry(gameid, player_info.z, player_info.hp,
+                           player_info.hpmax, player_info.gold,
+                           player_info.moves, player_info.en,
+                           player_info.enmax, player_info.st,
+                           player_info.in, player_info.wi, player_info.dx,
+                           player_info.co, player_info.ch, player_info.score);
         log_msg("%s has created a new game (%d) as %s", user_info.username,
                 gameid, name);
         j_msg = json_pack("{si}", "return", gameid);
@@ -349,6 +355,7 @@ ccmd_play_game(json_t * params)
              "list?",
              "yn", 'n') == 'y') {
             db_delete_game(user_info.uid, gid);
+            db_delete_binge_entry(gid);
             log_msg("%s has chosen to remove game %d from the database",
                     user_info.username, gid);
         }
@@ -358,6 +365,13 @@ ccmd_play_game(json_t * params)
 
     db_update_game(gid, player_info.moves, player_info.z,
                    player_info.level_desc);
+
+    db_update_binge_entry(gid, player_info.z, player_info.hp,
+                          player_info.hpmax, player_info.gold,
+                          player_info.moves, player_info.en,
+                          player_info.enmax, player_info.st,
+                          player_info.in, player_info.wi, player_info.dx,
+                          player_info.co, player_info.ch, player_info.score);
 
     /* move the finished game to its final resting place */
     if (status == GAME_OVER) {
@@ -394,6 +408,13 @@ ccmd_exit_game(json_t * params)
     if (status) {
         db_update_game(gameid, player_info.moves, player_info.z,
                        player_info.level_desc);
+        db_update_binge_entry(gameid, player_info.z, player_info.hp,
+                              player_info.hpmax, player_info.gold,
+                              player_info.moves, player_info.en,
+                              player_info.enmax, player_info.st,
+                              player_info.in, player_info.wi, player_info.dx,
+                              player_info.co, player_info.ch, player_info.score);
+
         log_msg("%s has closed game %d", user_info.username, gameid);
         gameid = -1;
         close(gamefd);

--- a/nethack_server/src/winprocs.c
+++ b/nethack_server/src/winprocs.c
@@ -282,6 +282,13 @@ srv_update_status(struct nh_player_info *pi)
     }
     player_info = *pi;
 
+    db_update_binge_entry(gameid, player_info.z, player_info.hp,
+                          player_info.hpmax, player_info.gold,
+                          player_info.moves, player_info.en,
+                          player_info.enmax, player_info.st,
+                          player_info.in, player_info.wi, player_info.dx,
+                          player_info.co, player_info.ch, player_info.score);
+
     add_display_data("update_status", jobj);
 }
 


### PR DESCRIPTION
Adds the bingeboard table to the database.
This table stores stats about the player that are updated on each turn.

A working example of this being utilized is at https://binge.csh.rit.edu
This example provided by:
https://github.com/liam-middlebrook/bingehack4-binge-api
https://github.com/liam-middlebrook/bingehack4-bingeboard-web

Once this is merged I'll transfer ownership of the two repos listed above to ComputerScienceHouse's GitHub organization so it's "official"

I already have this running on bingehack prod, but I figure it's better to get review before officially merging it in.

Fixes #43 