### PR TITLE
Add DroneCI Support

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,12 @@
+pipeline:
+  build:
+    image: ubuntu:14.04
+    commands:
+    # set lang for unicode support
+      - export LC_ALL=C.UTF-8
+    # bingehack prep
+      - apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 16126D3A3E5C1192
+      - apt-get update -qq
+      - apt-get install -qq g++ gcc flex bison libbison-dev libjansson-dev postgresql-client libpq-dev libsdl2-dev libpng-dev
+    # bingehack build
+      - ./travis-build

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/ComputerScienceHouse/bingehack4.png?branch=master)](https://travis-ci.org/ComputerScienceHouse/bingehack4)
+[![Build Status](https://drone.csh.rit.edu/api/badges/ComputerScienceHouse/bingehack4/status.svg)](https://drone.csh.rit.edu/ComputerScienceHouse/bingehack4)
 
 # BingeHack 4 #
 
@@ -44,6 +45,7 @@ We test our client game terminal support for functionality on:
 
 * [Play BingeHack4!](telnet://bingehack.csh.rit.edu)
 * [CSH's Travis-CI Build Server: BingeHack4 Project](https://travis-ci.org/ComputerScienceHouse/bingehack4)
+* [CSH's Drone Build Server: BingeHack4 Project](https://drone.csh.rit.edu/ComputerScienceHouse/bingehack4)
 * [BingeHack4's Wiki](https://github.com/ComputerScienceHouse/bingehack4/wiki)
 * [Upstream NetHack4 Git Repository](http://gitorious.org/nitrohack/ais523/commits/nicehack)
 

--- a/travis-build
+++ b/travis-build
@@ -16,7 +16,7 @@ elif [[ "$BUILD_SYSTEM" == aimake ]]; then
 	tempfile="$(mktemp)"
 	trap "rm -f \"$tempfile\"" EXIT ERR
 
-	../aimake --with=server -i /tmp/bingehack4 2>&1 | tee "$tempfile"
+	../aimake --no-sanity-checks --with=server -i /tmp/bingehack4 2>&1 | tee "$tempfile"
 	grep -qi "fail" "$tempfile" && exit 1
 else
 	echo "Unsupported build system $BUILD_SYSTEM" >&2


### PR DESCRIPTION
DroneCI allows for local containerized builds. It's a new thing we're
trying out so I figured I'd start by porting this beast over. I'll
probably need to mess around to get matrix builds working so that we get
different compilers and versions going.

(the badge link may be funky since I wrote it for being on this repo, if you wanna see what it would look like just change it from `ComputerScienceHouse` to `liam-middlebrook`)