### PR TITLE
Add Dockerfile

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,15 +1,15 @@
 pipeline:
   build:
-    image: ubuntu:15.04
+    image: computersciencehouse/bingehack4:latest
     commands:
     # set lang for unicode support
       - export LC_ALL=C.UTF-8
-    # bingehack prep
-      - apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 16126D3A3E5C1192
-      - apt-get update -qq
-      - apt-get install -qq binutils ${CC} ${CXX} flex bison libbison-dev libjansson-dev postgresql-client libpq-dev libsdl2-dev libpng-dev
     # bingehack build
       - ./travis-build
+
+# We still need this matrix to match what versions are listed in the Dockerfile.
+# That way we can still test against different compiler versions
+
 matrix:
   include:
     - CC: gcc-4.6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:15.04
+MAINTAINER Liam Middlebrook <loothelion@csh.rit.edu>
+
+# Install all of the dependencies needed to build Bingehack4
+
+ENV compilers gcc-4.6 g++-4.6 gcc-4.7 g++-4.7 gcc-4.8 g++-4.8 clang-3.4 clang-3.4 clang-3.5 clang-3.5
+
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 16126D3A3E5C1192
+RUN apt-get update -qq
+RUN apt-get install -qq binutils $compilers flex bison libbison-dev libjansson-dev postgresql-client libpq-dev libsdl2-dev libpng-dev


### PR DESCRIPTION
This adds a Dockerfile based build-environment container for Bingehack4. I've also made changes to the .drone.yml file to use the most recent image uploaded to Dockerhub (right now this is pointing to an image generated from my fork so that I won't have to change anything in-repo after it's merged in for CI to be happy)

Here's a log of Drone running before the change: https://drone.csh.rit.edu/liam-middlebrook/bingehack4/52/1

And here's a log of Drone running after the change: https://drone.csh.rit.edu/liam-middlebrook/bingehack4/56/1

As you can see there's roughly a 5x speedup for Drone after this change.

Fixes #76