### PR TITLE
Update Gemfile.lock net-ldap Dependency

### DIFF
--- a/scripts/nethack_events/bingehack-tweeter/Gemfile.lock
+++ b/scripts/nethack_events/bingehack-tweeter/Gemfile.lock
@@ -5,7 +5,7 @@ GEM
       multipart-post (~> 1.1)
     multi_json (1.3.6)
     multipart-post (1.1.5)
-    net-ldap (0.3.1)
+    net-ldap (0.16.0)
     simple_oauth (0.2.0)
     twitter (4.8.1)
       faraday (~> 0.8, < 0.10)


### PR DESCRIPTION
Update the net-ldap required version to 0.16.0.

I tested this locally and it tweeted at me successfully.

Requesting @stevenmirabito's review for priority reasons.